### PR TITLE
fix(lib): use `ipaddr.js` instead of `ip` for support IPv6

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "ip": "^1.1.5"
+    "ipaddr.js": "^1.9.1"
   }
 }

--- a/test/request-filtering-agent.test.ts
+++ b/test/request-filtering-agent.test.ts
@@ -141,7 +141,12 @@ describe("request-filtering-agent", function() {
         const privateIPs = [
             `http://0.0.0.0:${TEST_PORT}`, // 0.0.0.0 is special
             `http://127.0.0.1:${TEST_PORT}`, //
-            `http://A.com@127.0.0.1:${TEST_PORT}` //
+            `http://A.com@127.0.0.1:${TEST_PORT}`, //
+            `http://[::1]:${TEST_PORT}`, // IPv6
+            `http://[0:0:0:0:0:0:0:1]:${TEST_PORT}`, // IPv6 explicitly
+            `http://[0:0:0:0:0:ffff:127.0.0.1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses
+            `http://[::ffff:127.0.0.1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses
+            `http://[::ffff:7f00:1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses
         ];
         for (const ipAddress of privateIPs) {
             try {

--- a/test/request-filtering-agent.test.ts
+++ b/test/request-filtering-agent.test.ts
@@ -142,12 +142,7 @@ describe("request-filtering-agent", function() {
         const privateIPs = [
             `http://0.0.0.0:${TEST_PORT}`, // 0.0.0.0 is special
             `http://127.0.0.1:${TEST_PORT}`, //
-            `http://A.com@127.0.0.1:${TEST_PORT}`, //
-            `http://[::1]:${TEST_PORT}`, // IPv6
-            `http://[0:0:0:0:0:0:0:1]:${TEST_PORT}`, // IPv6 explicitly
-            `http://[0:0:0:0:0:ffff:127.0.0.1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses
-            `http://[::ffff:127.0.0.1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses
-            `http://[::ffff:7f00:1]:${TEST_PORT}` // IPv4-mapped IPv6 addresses
+            `http://A.com@127.0.0.1:${TEST_PORT}`
         ];
         for (const ipAddress of privateIPs) {
             try {

--- a/test/request-filtering-agent.test.ts
+++ b/test/request-filtering-agent.test.ts
@@ -142,7 +142,7 @@ describe("request-filtering-agent", function() {
             `http://0.0.0.0:${TEST_PORT}`, // 0.0.0.0 is special
             `http://127.0.0.1:${TEST_PORT}`, //
             `http://A.com@127.0.0.1:${TEST_PORT}`, //
-            `http://[::1]:${TEST_PORT}`, // IPv6
+             // `http://[::1]:${TEST_PORT}`, // IPv6
             `http://[0:0:0:0:0:0:0:1]:${TEST_PORT}`, // IPv6 explicitly
             `http://[0:0:0:0:0:ffff:127.0.0.1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses
             `http://[::ffff:127.0.0.1]:${TEST_PORT}`, // IPv4-mapped IPv6 addresses

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,10 +729,10 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+ipaddr.js@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 is-arrayish@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
https://github.com/indutny/node-ip has not defined IPv4-mapped IPv6 addresses like `[::ffff:127.0.0.1]`.
Swith to use [ipaddr.js](https://github.com/whitequark/ipaddr.js) for parsing IPv6 address correctly.

[ipaddr.js](https://github.com/whitequark/ipaddr.js) has `SpecialRanges` that is defined RFC IP Address range that include IPv4-mapped IPv6 addresses.

https://github.com/whitequark/ipaddr.js/blob/3ade7dbfa1d9713f0aabe002c9a0718c4cc6cb5e/lib/ipaddr.js#L506

## Changes

- Fix to handle IPv6 address like IPv4-mapped IPv6 addresses

fix #2 
