### PR TITLE
added functionality to stop request even if socket is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ export interface RequestFilteringAgentOptions {
     // Deny address list
     // Default: []
     denyIPAddressList?: string[]
+    // prevent url redirection attack
+    // connection not made to private IP adresses where the port is closed
+    // Default: false
+    stopPortScanningByUrlRedirection?: boolean;
 }
 /**
  * Apply request filter to http(s).Agent instance


### PR DESCRIPTION
Why is this useful?
- This prevents a url redirection attack where a malicious user redirects to a localhost port and identifies which ports are open or not

What happened before this?
- Response would be ECONNREFUSED which lets a malicious user know that the port is closed.

An optional parameter has been created so that the feature can be turned on, default is that the feature is turned off

